### PR TITLE
If linter validation fails - k8comp should exit and not continue the deployment

### DIFF
--- a/bin/k8comp
+++ b/bin/k8comp
@@ -641,6 +641,7 @@ version: ${helmpv}" > ./${helm_package_name}/Chart.yaml
         message_green "helm chart: ${helm_package_name}-${helmpv}"
     else
         error "there are some errors with your current deployment"
+        exit 1
     fi
     if [ -d ./${helm_package_name} ]
     then


### PR DESCRIPTION
This is an attempt to fix a bug in our ci pipeline where the helm deployment would continue even if k8comp had found errors in the template.